### PR TITLE
made more responsive without affecting map or index.html.erb code

### DIFF
--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -1,13 +1,11 @@
 .index-container {
-  margin-top: 20px;
-  margin-bottom: 20px;
-  max-width: 100%;
-  overflow: hidden;
+  position: relative;
 }
 
-.index-title {
-  font-family: 'Karla', sans-serif;
-  margin-top: 0;
+.index-content {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-gap: 30px;
 }
 
 .index-card {
@@ -60,6 +58,6 @@
 
 @media (max-width: 768px) {
   .index-card {
-    width: 100%;
+    height: auto;
   }
 }


### PR DESCRIPTION
1. Made the heights for index cards "auto" so they can effectively resize when the viewport width is below a certain threshold
2. Index page remains unaffected and map stickiness is preserved
3. Fixes issue where the image fails to fill its container when the tab is minimised as shown below in the top screenshot                          ![image](https://github.com/08Cyrine08/EvVen/assets/85987546/02aca3d6-7b13-4416-a733-0a8f4777b906)